### PR TITLE
move externalLight to Settings.h

### DIFF
--- a/printermonitor/Settings.h
+++ b/printermonitor/Settings.h
@@ -84,6 +84,9 @@ const int SCL_PIN = D5;
 const boolean INVERT_DISPLAY = false; // true = pins at top | false = pins at the bottom
 //#define DISPLAY_SH1106       // Uncomment this line to use the SH1106 display -- SSD1306 is used by default and is most common
 
+// LED Settings
+const int externalLight = LED_BUILTIN; // Set to unused pin, like D1, to disable use of built-in LED (LED_BUILTIN)
+
 boolean ENABLE_OTA = true;     // this will allow you to load firmware to the device over WiFi (see OTA for ESP8266)
 String OTA_Password = "";      // Set an OTA password here -- leave blank if you don't want to be prompted for password
 //******************************

--- a/printermonitor/printermonitor.ino
+++ b/printermonitor/printermonitor.ino
@@ -155,9 +155,6 @@ String COLOR_THEMES = "<option>red</option>"
                       "<option>w3schools</option>";
                             
 
-// Change the externalLight to the pin you wish to use if other than the Built-in LED
-int externalLight = LED_BUILTIN; // LED_BUILTIN is is the built in LED on the Wemos
-
 void setup() {
   Serial.begin(115200);
   SPIFFS.begin();


### PR DESCRIPTION
Defining externalLight with an unused pin allows a more obvious way for disabling the use of the built-in led without having to modify the board physically and without having to create a wrapper for every digitalWrite() for the led pin.

The walls of the printed case are slim enough to allow the built-in light to be visible when blinking during every update. When the case is constantly within view, this blinking behaviour can become an annoying feature and having it configurable within software is the better approach from having to physically modify the board itself. Moving externalLight to Settings.h makes the existence of configurability more easily found.