### PR TITLE
restore SSD1306 as default display

### DIFF
--- a/printermonitor/Settings.h
+++ b/printermonitor/Settings.h
@@ -84,7 +84,7 @@ const int I2C_DISPLAY_ADDRESS = 0x3c; // I2C Address of your Display (usually 0x
 const int SDA_PIN = D2;
 const int SCL_PIN = D5;
 boolean INVERT_DISPLAY = false; // true = pins at top | false = pins at the bottom
-#define DISPLAY_SH1106       // Uncomment this line to use the SH1106 display -- SSD1306 is used by default and is most common
+//#define DISPLAY_SH1106       // Uncomment this line to use the SH1106 display -- SSD1306 is used by default and is most common
 
 boolean ENABLE_OTA = true;     // this will allow you to load firmware to the device over WiFi (see OTA for ESP8266)
 String OTA_Password = "";      // Set an OTA password here -- leave blank if you don't want to be prompted for password


### PR DESCRIPTION
Most likely unintentionally changed in commit 04ed5ae77dc0d0fecfd6e71887713f089e0ec9ed as the comment no longer matches the suggested setting. Using the wrong display setting for a SSD1306 display results in some garbage being shown as extra on the display causing false concern that something buggy has been included in the new release.