### PR TITLE
Add ability to respect PSU status if psucontrol plugin is used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ SOFTWARE.
 * Supports OTA (loading firmware over WiFi connection on same LAN)
 * Basic Authentication to protect your settings
 * Version 2.2 added the ability to update firmware through web interface from a compiled binary
+* Can query the Octoprint [https://plugins.octoprint.org/plugins/psucontrol/](PSU Control plugin) to enter clock or blank mode when PSU is off
 * Video: https://youtu.be/niRv9SCgAPk
 * Detailed build video by Chris Riley: https://youtu.be/Rm-l1FSuJpI
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ SOFTWARE.
 * Supports OTA (loading firmware over WiFi connection on same LAN)
 * Basic Authentication to protect your settings
 * Version 2.2 added the ability to update firmware through web interface from a compiled binary
-* Can query the Octoprint [https://plugins.octoprint.org/plugins/psucontrol/](PSU Control plugin) to enter clock or blank mode when PSU is off
+* Can query the Octoprint [PSU Control plugin](https://plugins.octoprint.org/plugins/psucontrol/) to enter clock or blank mode when PSU is off
 * Video: https://youtu.be/niRv9SCgAPk
 * Detailed build video by Chris Riley: https://youtu.be/Rm-l1FSuJpI
 

--- a/printermonitor/OctoPrintClient.h
+++ b/printermonitor/OctoPrintClient.h
@@ -21,6 +21,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+/* 15 Jan 2019 : Owen Carter : Add psucontrol query via POST api call */
+
 #pragma once
 #include <ESP8266WiFi.h>
 #include <ArduinoJson.h>
@@ -33,11 +35,13 @@ private:
   int myPort = 80;
   String myApiKey = "";
   String encodedAuth = "";
+  boolean pollPsu;
 
   void resetPrintData();
   boolean validate();
   WiFiClient getSubmitRequest(String apiGetData);
-  
+  WiFiClient getPostRequest(String apiPostData, String apiPostBody);
+ 
   String result;
 
   typedef struct {
@@ -57,6 +61,7 @@ private:
     String bedTemp;
     String bedTargetTemp;
     boolean isPrinting;
+    boolean isPSUoff;
     String error;
   } PrinterStruct;
 
@@ -64,9 +69,10 @@ private:
 
   
 public:
-  OctoPrintClient(String ApiKey, String server, int port, String user, String pass);
+  OctoPrintClient(String ApiKey, String server, int port, String user, String pass, boolean psu);
   void getPrinterJobResults();
-  void updateOctoPrintClient(String ApiKey, String server, int port, String user, String pass);
+  void getPrinterPsuState();
+  void updateOctoPrintClient(String ApiKey, String server, int port, String user, String pass, boolean psu);
 
   String getAveragePrintTime();
   String getEstimatedPrintTime();
@@ -80,6 +86,7 @@ public:
   String getState();
   boolean isPrinting();
   boolean isOperational();
+  boolean isPSUoff();
   String getTempBedActual();
   String getTempBedTarget();
   String getTempToolActual();

--- a/printermonitor/Settings.h
+++ b/printermonitor/Settings.h
@@ -21,6 +21,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+/* 15 Jan 2019 : Owen Carter : Add psucontrol setting */
+
 /******************************************************************************
  * Printer Monitor is designed for the Wemos D1 ESP8266
  * Wemos D1 Mini:  https://amzn.to/2qLyKJd
@@ -71,11 +73,14 @@ boolean IS_METRIC = false; // false = Imperial and true = Metric
 // Languages: ar, bg, ca, cz, de, el, en, fa, fi, fr, gl, hr, hu, it, ja, kr, la, lt, mk, nl, pl, pt, ro, ru, se, sk, sl, es, tr, ua, vi, zh_cn, zh_tw
 String WeatherLanguage = "en";  //Default (en) English
 
+// Webserver
 const int WEBSERVER_PORT = 80; // The port you can access this device on over HTTP
 const boolean WEBSERVER_ENABLED = true;  // Device will provide a web interface via http://[ip]:[port]/
 boolean IS_BASIC_AUTH = true;  // true = require athentication to change configuration settings / false = no auth
 char* www_username = "admin";  // User account for the Web Interface
 char* www_password = "password";  // Password for the Web Interface
+
+// Date and Time
 float UtcOffset = -7; // Hour offset from GMT for your timezone
 boolean IS_24HOUR = false;     // 23:00 millitary 24 hour clock
 int minutesBetweenDataRefresh = 15;
@@ -91,8 +96,13 @@ boolean INVERT_DISPLAY = false; // true = pins at top | false = pins at the bott
 // LED Settings
 const int externalLight = LED_BUILTIN; // Set to unused pin, like D1, to disable use of built-in LED (LED_BUILTIN)
 
+// PSU Control
+boolean HAS_PSU = false; // Set to true if https://github.com/kantlivelong/OctoPrint-PSUControl/ in use
+
+// OTA Updates
 boolean ENABLE_OTA = true;     // this will allow you to load firmware to the device over WiFi (see OTA for ESP8266)
 String OTA_Password = "";      // Set an OTA password here -- leave blank if you don't want to be prompted for password
+
 //******************************
 // End Settings
 //******************************


### PR DESCRIPTION
I did this for my build of the monitor (https://www.thingiverse.com/make:594876) 

I always have my Pi and (Duet) Controller powered up and 'operational', but still wanted the monitor to go to sleep/clock/weather when the printer is powered down. These changes add a setting for 'psucontrol', which is saved and configured via the web like any other.

Enabling this adds an extra API call to get the psu status, and sets a 'psu is off' flag only if the plugin responds, and is off. It assumes psu is on by default otherwise. This flag then activates the clock mode even if the status is otherwise 'operational', changes the 'offline' message on the clock display to 'psu off' and adds a note to the status display in the web client.

I have added/cleaned up a few comments, plus made two real changes: The 'offline/psu off' message is pushed up by a single pixel in the display, which makes the 'p' in 'psu' readable, it doesn't seem to affect anything else, ymmv.  I also 'improved' how errors are presented in the web client, giving the status as 'offline' and the error message below. This seems to more accurately reflect what the display will be showing; again, ymmv.

This is more coding than I've done in 25 years so please bear with me if I've made some grisly mistakes, it was more complex than I expected since the psucontrol plugin has no GET method to retrieve it's status, and I had to add a POST request function, then spend half a evening getting that to work. I so love JSONs syntax handling, it's so forgiving.. :-(
I should probably have overloaded the existing functions or something to add a `POST` request mechanism to the existing `getSubmitRequest`. and some better way to pass the `HAS_PSU` config to the OctoPrintClient function. Vague apologies if my solutions look awkward to those with more skillz.