### PR TITLE
Migration from deprecated SPIFFS to LittleFS

### DIFF
--- a/printermonitor/Settings.h
+++ b/printermonitor/Settings.h
@@ -49,6 +49,7 @@ SOFTWARE.
 #include "OctoPrintClient.h"
 #include "OpenWeatherMapClient.h"
 #include "WeatherStationFonts.h"
+#include "LittleFS.h"
 #include "FS.h"
 #include "SH1106Wire.h"
 #include "SSD1306Wire.h"

--- a/printermonitor/printermonitor.ino
+++ b/printermonitor/printermonitor.ino
@@ -198,7 +198,7 @@ static const char COLOR_THEMES[] PROGMEM = "<option>red</option>"
 
 void setup() {  
   Serial.begin(115200);
-  SPIFFS.begin();
+  LittleFS.begin();
   delay(10);
   
   //New Line to clear from start garbage
@@ -435,7 +435,7 @@ void handleSystemReset() {
     return server.requestAuthentication();
   }
   Serial.println("Reset System Configuration");
-  if (SPIFFS.remove(CONFIG)) {
+  if (LittleFS.remove(CONFIG)) {
     redirectHome();
     ESP.restart();
   }
@@ -1114,8 +1114,8 @@ int8_t getWifiQuality() {
 
 
 void writeSettings() {
-  // Save decoded message to SPIFFS file for playback on power up.
-  File f = SPIFFS.open(CONFIG, "w");
+  // Save decoded message to LittleFS file for playback on power up.
+  File f = LittleFS.open(CONFIG, "w");
   if (!f) {
     Serial.println("File open failed!");
   } else {
@@ -1150,12 +1150,12 @@ void writeSettings() {
 }
 
 void readSettings() {
-  if (SPIFFS.exists(CONFIG) == false) {
+  if (LittleFS.exists(CONFIG) == false) {
     Serial.println("Settings File does not yet exists.");
     writeSettings();
     return;
   }
-  File fr = SPIFFS.open(CONFIG, "r");
+  File fr = LittleFS.open(CONFIG, "r");
   String line;
   while(fr.available()) {
     line = fr.readStringUntil('\n');


### PR DESCRIPTION
Cause:
warning: 'SPIFFS' is deprecated
=> https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-deprecation-warning

Modification:
changed all "SPIFFS" calls to "LittleFS" and added include LittleFS.h


compilation tested with Arduino V1.8.13 & ESP8266 Board V2.7.2/V2.7.3


Signed-off-by: Oliver Fassbender <git@intrepid.de>